### PR TITLE
Custom DestopPane UIs may cause ClassCastException

### DIFF
--- a/substance/src/main/java/org/pushingpixels/substance/internal/utils/SubstanceCoreUtilities.java
+++ b/substance/src/main/java/org/pushingpixels/substance/internal/utils/SubstanceCoreUtilities.java
@@ -1763,7 +1763,7 @@ public class SubstanceCoreUtilities {
 	public static JComponent getTitlePane(JRootPane rootPane) {
 		JInternalFrame jif = (JInternalFrame) SwingUtilities
 				.getAncestorOfClass(JInternalFrame.class, rootPane);
-		if (jif != null) {
+		if ((jif != null) && (jif.getUI() instanceof SubstanceInternalFrameUI)) {
 			SubstanceInternalFrameUI ui = (SubstanceInternalFrameUI) jif
 					.getUI();
 			return ui.getTitlePane();


### PR DESCRIPTION
Custom non-Susbstance DesktopPaneUI may cause this error.
