### PR TITLE
Insubstantial Issue #68: BaseColorScheme API too limiting

### DIFF
--- a/substance/src/main/java/org/pushingpixels/substance/api/SchemeDerivedColorsResolver.java
+++ b/substance/src/main/java/org/pushingpixels/substance/api/SchemeDerivedColorsResolver.java
@@ -1,0 +1,107 @@
+package org.pushingpixels.substance.api;
+
+import java.awt.Color;
+
+
+/**
+ * {@code SchemeDerivedColorResolver}s must be immutable. The resolvers are passed to derived color
+ * schemes to ensure that derived scheme resolve derived colors in the same way as the base scheme.
+ * 
+ * @author Karl Schaefer
+ */
+public interface SchemeDerivedColorsResolver {
+    /**
+     * Determines if this resolver is for dark color schemes.
+     * 
+     * @return <code>true</code> if it should be used in dark schemes
+     */
+    boolean isDark();
+    
+    /**
+     * Inverts this resolver, for use with inverted color schemes and switching from light to dark
+     * schemes or vice versa.
+     * <p>
+     * Some resolvers may not support this option. They may choose to throw an
+     * {@code UnsupportedOperationException} in that case. Instead of throwing the exception
+     * developers may choose to simply return {@code this} signifying that the resolver cannot be
+     * inverted. Another option would be to use assertions, allowing the developers to discover
+     * mistakes during creation, but still being useful for clients:
+     * 
+     * <pre>
+     * public void SchemeDerivedColorsResolver invert() {
+     *     assert false : "this resolver cannot be inverted";
+     *     
+     *     return this;
+     * }
+     * </pre>
+     * 
+     * 
+     * @return an inversion of this resolver
+     * @throws UnsupportedOperationException
+     *             if this resolver cannot be inverted
+     */
+    SchemeDerivedColorsResolver invert();
+    
+    /**
+     * Resolves a derived color for a given color scheme.
+     * 
+     * @return the watermark stamp color for the supplied scheme.
+     */
+    Color getWatermarkStampColor(SubstanceColorScheme colorScheme);
+
+    /**
+     * Returns the watermark light color for <code>this</code> scheme.
+     * 
+     * @return Watermark light color for <code>this</code> scheme.
+     */
+    Color getWatermarkLightColor(SubstanceColorScheme colorScheme);
+
+    /**
+     * Returns the watermark dark color for <code>this</code> scheme.
+     * 
+     * @return Watermark dark color for <code>this</code> scheme.
+     */
+    Color getWatermarkDarkColor(SubstanceColorScheme colorScheme);
+
+    /**
+     * Returns the line color for <code>this</code> scheme.
+     * 
+     * @return The line color for <code>this</code> scheme.
+     */
+    Color getLineColor(SubstanceColorScheme colorScheme);
+
+    /**
+     * Returns the selection background color for <code>this</code> scheme.
+     * 
+     * @return The selection background color for <code>this</code> scheme.
+     */
+    Color getSelectionBackgroundColor(SubstanceColorScheme colorScheme);
+
+    /**
+     * Returns the selection foreground color for <code>this</code> scheme.
+     * 
+     * @return The selection foreground color for <code>this</code> scheme.
+     */
+    Color getSelectionForegroundColor(SubstanceColorScheme colorScheme);
+
+    /**
+     * Returns the background fill color for <code>this</code> scheme.
+     * 
+     * @return The background fill color for <code>this</code> scheme.
+     */
+    Color getBackgroundFillColor(SubstanceColorScheme colorScheme);
+
+    /**
+     * Returns the text background fill color for <code>this</code> scheme.
+     * 
+     * @return The text background fill color for <code>this</code> scheme.
+     */
+    Color getTextBackgroundFillColor(SubstanceColorScheme colorScheme);
+
+    /**
+     * Returns the focus ring color for <code>this</code> scheme.
+     * 
+     * @return The focus ring color for <code>this</code> scheme.
+     */
+    Color getFocusRingColor(SubstanceColorScheme colorScheme);
+}

--- a/substance/src/main/java/org/pushingpixels/substance/api/colorscheme/DerivedColorsResolverDark.java
+++ b/substance/src/main/java/org/pushingpixels/substance/api/colorscheme/DerivedColorsResolverDark.java
@@ -31,7 +31,7 @@ package org.pushingpixels.substance.api.colorscheme;
 
 import java.awt.Color;
 
-import org.pushingpixels.substance.api.SchemeDerivedColors;
+import org.pushingpixels.substance.api.SchemeDerivedColorsResolver;
 import org.pushingpixels.substance.api.SubstanceColorScheme;
 import org.pushingpixels.substance.internal.utils.SubstanceColorUtilities;
 
@@ -40,47 +40,31 @@ import org.pushingpixels.substance.internal.utils.SubstanceColorUtilities;
  * accessible outside the package and is for internal use only.
  * 
  * @author Kirill Grouchnikov
+ * @author Karl Schaefer (immutable redesign)
  */
-class DerivedColorsResolverDark implements SchemeDerivedColors {
-	/**
-	 * The original color scheme.
-	 */
-	SubstanceColorScheme scheme;
+//TODO this class should be final
+class DerivedColorsResolverDark implements SchemeDerivedColorsResolver {
+    static final DerivedColorsResolverDark INSTANCE = new DerivedColorsResolverDark();
+    
+    @Override
+    public boolean isDark() {
+        return true;
+    }
 
-	/**
-	 * Creates the resolver of derived colors for the specified dark color
-	 * scheme.
-	 * 
-	 * @param scheme
-	 *            The original color scheme.
-	 */
-	public DerivedColorsResolverDark(SubstanceColorScheme scheme) {
-		if (!scheme.isDark()) {
-			throw new IllegalArgumentException("The scheme must be dark: "
-					+ scheme.getDisplayName());
-		}
-		this.scheme = scheme;
-	}
+    @Override
+    public SchemeDerivedColorsResolver invert() {
+        return DerivedColorsResolverLight.INSTANCE;
+    }
 
-	/*
-	 * (non-Javadoc)
-	 * 
-	 * @see org.pushingpixels.substance.api.SchemeDerivedColors#getWatermarkStampColor()
-	 */
 	@Override
-	public Color getWatermarkStampColor() {
-		return SubstanceColorUtilities.getAlphaColor(this.scheme
+	public Color getWatermarkStampColor(SubstanceColorScheme colorScheme) {
+		return SubstanceColorUtilities.getAlphaColor(colorScheme
 				.getUltraLightColor(), 30);
 	}
 
-	/*
-	 * (non-Javadoc)
-	 * 
-	 * @see org.pushingpixels.substance.api.SchemeDerivedColors#getWatermarkDarkColor()
-	 */
 	@Override
-	public Color getWatermarkDarkColor() {
-		return this.scheme.getLightColor();
+	public Color getWatermarkDarkColor(SubstanceColorScheme colorScheme) {
+		return colorScheme.getLightColor();
 	}
 
 	/*
@@ -89,8 +73,8 @@ class DerivedColorsResolverDark implements SchemeDerivedColors {
 	 * @see org.pushingpixels.substance.api.SchemeDerivedColors#getWatermarkLightColor()
 	 */
 	@Override
-    public Color getWatermarkLightColor() {
-		return this.scheme.getUltraLightColor();
+    public Color getWatermarkLightColor(SubstanceColorScheme colorScheme) {
+		return colorScheme.getUltraLightColor();
 	}
 
 	/*
@@ -99,8 +83,8 @@ class DerivedColorsResolverDark implements SchemeDerivedColors {
 	 * @see org.pushingpixels.substance.api.SchemeDerivedColors#getLineColor()
 	 */
 	@Override
-	public Color getLineColor() {
-		return this.scheme.getMidColor();
+	public Color getLineColor(SubstanceColorScheme colorScheme) {
+		return colorScheme.getMidColor();
 	}
 
 	/*
@@ -110,8 +94,8 @@ class DerivedColorsResolverDark implements SchemeDerivedColors {
 	 * org.pushingpixels.substance.api.SchemeDerivedColors#getSelectionForegroundColor()
 	 */
 	@Override
-	public Color getSelectionForegroundColor() {
-		return this.scheme.getUltraDarkColor().darker();
+	public Color getSelectionForegroundColor(SubstanceColorScheme colorScheme) {
+		return colorScheme.getUltraDarkColor().darker();
 	}
 
 	/*
@@ -121,8 +105,8 @@ class DerivedColorsResolverDark implements SchemeDerivedColors {
 	 * org.pushingpixels.substance.api.SchemeDerivedColors#getSelectionBackgroundColor()
 	 */
 	@Override
-	public Color getSelectionBackgroundColor() {
-		return this.scheme.getUltraLightColor().brighter();
+	public Color getSelectionBackgroundColor(SubstanceColorScheme colorScheme) {
+		return colorScheme.getUltraLightColor().brighter();
 	}
 
 	/*
@@ -131,8 +115,8 @@ class DerivedColorsResolverDark implements SchemeDerivedColors {
 	 * @see org.pushingpixels.substance.api.SchemeDerivedColors#getBackgroundFillColor()
 	 */
 	@Override
-	public Color getBackgroundFillColor() {
-		return this.scheme.getDarkColor().brighter();
+	public Color getBackgroundFillColor(SubstanceColorScheme colorScheme) {
+		return colorScheme.getDarkColor().brighter();
 	}
 
 	/*
@@ -141,8 +125,8 @@ class DerivedColorsResolverDark implements SchemeDerivedColors {
 	 * @see org.pushingpixels.substance.api.SchemeDerivedColors#getFocusRingColor()
 	 */
 	@Override
-	public Color getFocusRingColor() {
-		return this.scheme.getUltraDarkColor();
+	public Color getFocusRingColor(SubstanceColorScheme colorScheme) {
+		return colorScheme.getUltraDarkColor();
 	}
 
 	/*
@@ -152,8 +136,8 @@ class DerivedColorsResolverDark implements SchemeDerivedColors {
 	 * org.pushingpixels.substance.api.SchemeDerivedColors#getTextBackgroundFillColor()
 	 */
 	@Override
-	public Color getTextBackgroundFillColor() {
-		return SubstanceColorUtilities.getInterpolatedColor(this.scheme
-				.getMidColor(), this.scheme.getLightColor(), 0.4);
+	public Color getTextBackgroundFillColor(SubstanceColorScheme colorScheme) {
+		return SubstanceColorUtilities.getInterpolatedColor(colorScheme
+				.getMidColor(), colorScheme.getLightColor(), 0.4);
 	}
 }

--- a/substance/src/main/java/org/pushingpixels/substance/api/colorscheme/DerivedColorsResolverLight.java
+++ b/substance/src/main/java/org/pushingpixels/substance/api/colorscheme/DerivedColorsResolverLight.java
@@ -31,7 +31,7 @@ package org.pushingpixels.substance.api.colorscheme;
 
 import java.awt.Color;
 
-import org.pushingpixels.substance.api.SchemeDerivedColors;
+import org.pushingpixels.substance.api.SchemeDerivedColorsResolver;
 import org.pushingpixels.substance.api.SubstanceColorScheme;
 import org.pushingpixels.substance.internal.utils.SubstanceColorUtilities;
 
@@ -40,132 +40,68 @@ import org.pushingpixels.substance.internal.utils.SubstanceColorUtilities;
  * accessible outside the package and is for internal use only.
  * 
  * @author Kirill Grouchnikov
+ * @author Karl Schaefer (immutable redesign)
  */
-public class DerivedColorsResolverLight implements SchemeDerivedColors {
-	/**
-	 * The original color scheme.
-	 */
-	SubstanceColorScheme scheme;
+//TODO this class should be final
+public class DerivedColorsResolverLight implements SchemeDerivedColorsResolver {
+    static final DerivedColorsResolverLight INSTANCE = new DerivedColorsResolverLight();
+    
+    @Override
+    public boolean isDark() {
+        return false;
+    }
 
-	/**
-	 * Creates the resolver of derived colors for the specified light color
-	 * scheme.
-	 * 
-	 * @param scheme
-	 *            The original color scheme.
-	 */
-	public DerivedColorsResolverLight(SubstanceColorScheme scheme) {
-		if (scheme.isDark()) {
-			throw new IllegalArgumentException("The scheme must be light: "
-					+ scheme.getDisplayName());
-		}
-		this.scheme = scheme;
-	}
-
-	/*
-	 * (non-Javadoc)
-	 * 
-	 * @see org.pushingpixels.substance.api.SchemeDerivedColors#getWatermarkStampColor()
-	 */
+    @Override
+    public SchemeDerivedColorsResolver invert() {
+        return DerivedColorsResolverDark.INSTANCE;
+    }
+    
 	@Override
-	public Color getWatermarkStampColor() {
-		return SubstanceColorUtilities.getAlphaColor(this.scheme.getMidColor(),
+	public Color getWatermarkStampColor(SubstanceColorScheme colorScheme) {
+		return SubstanceColorUtilities.getAlphaColor(colorScheme.getMidColor(),
 				50);
 	}
 
-	/*
-	 * (non-Javadoc)
-	 * 
-	 * @see org.pushingpixels.substance.api.SchemeDerivedColors#getWatermarkLightColor()
-	 */
 	@Override
-    public Color getWatermarkLightColor() {
-		return this.scheme.getLightColor();
+    public Color getWatermarkLightColor(SubstanceColorScheme colorScheme) {
+		return colorScheme.getLightColor();
 	}
 
-	/*
-	 * (non-Javadoc)
-	 * 
-	 * @see org.pushingpixels.substance.api.SchemeDerivedColors#getWatermarkDarkColor()
-	 */
 	@Override
-    public Color getWatermarkDarkColor() {
+    public Color getWatermarkDarkColor(SubstanceColorScheme colorScheme) {
 		return SubstanceColorUtilities.getAlphaColor(
-				this.scheme.getDarkColor(), 15);
+				colorScheme.getDarkColor(), 15);
 	}
 
-	/*
-	 * (non-Javadoc)
-	 * 
-	 * @see org.pushingpixels.substance.api.SchemeDerivedColors#getLineColor()
-	 */
 	@Override
-    public Color getLineColor() {
-		return SubstanceColorUtilities.getInterpolatedColor(this.scheme
-				.getMidColor(), this.scheme.getDarkColor(), 0.7);
+    public Color getLineColor(SubstanceColorScheme colorScheme) {
+		return SubstanceColorUtilities.getInterpolatedColor(colorScheme
+				.getMidColor(), colorScheme.getDarkColor(), 0.7);
 	}
 
-	/*
-	 * (non-Javadoc)
-	 * 
-	 * @see
-	 * org.pushingpixels.substance.api.SchemeDerivedColors#getSelectionForegroundColor()
-	 */
 	@Override
-	public Color getSelectionForegroundColor() {
-		return this.scheme.getUltraDarkColor().darker().darker();
+	public Color getSelectionForegroundColor(SubstanceColorScheme colorScheme) {
+		return colorScheme.getUltraDarkColor().darker().darker();
 	}
 
-	/*
-	 * (non-Javadoc)
-	 * 
-	 * @see
-	 * org.pushingpixels.substance.api.SchemeDerivedColors#getSelectionBackgroundColor()
-	 */
 	@Override
-	public Color getSelectionBackgroundColor() {
-		return this.scheme.getExtraLightColor();
+	public Color getSelectionBackgroundColor(SubstanceColorScheme colorScheme) {
+		return colorScheme.getExtraLightColor();
 	}
 
-	/*
-	 * (non-Javadoc)
-	 * 
-	 * @see java.lang.Object#toString()
-	 */
 	@Override
-	public String toString() {
-		return this.scheme.getDisplayName();
+	public Color getBackgroundFillColor(SubstanceColorScheme colorScheme) {
+		return colorScheme.getExtraLightColor();
 	}
 
-	/*
-	 * (non-Javadoc)
-	 * 
-	 * @see org.pushingpixels.substance.api.SchemeDerivedColors#getBackgroundFillColor()
-	 */
 	@Override
-	public Color getBackgroundFillColor() {
-		return this.scheme.getExtraLightColor();
+	public Color getFocusRingColor(SubstanceColorScheme colorScheme) {
+		return colorScheme.getDarkColor();
 	}
 
-	/*
-	 * (non-Javadoc)
-	 * 
-	 * @see org.pushingpixels.substance.api.SchemeDerivedColors#getFocusRingColor()
-	 */
 	@Override
-	public Color getFocusRingColor() {
-		return this.scheme.getDarkColor();
-	}
-
-	/*
-	 * (non-Javadoc)
-	 * 
-	 * @see
-	 * org.pushingpixels.substance.api.SchemeDerivedColors#getTextBackgroundFillColor()
-	 */
-	@Override
-	public Color getTextBackgroundFillColor() {
-		return SubstanceColorUtilities.getInterpolatedColor(this.scheme
-				.getUltraLightColor(), this.scheme.getExtraLightColor(), 0.8);
+	public Color getTextBackgroundFillColor(SubstanceColorScheme colorScheme) {
+		return SubstanceColorUtilities.getInterpolatedColor(colorScheme
+				.getUltraLightColor(), colorScheme.getExtraLightColor(), 0.8);
 	}
 }

--- a/substance/src/main/java/org/pushingpixels/substance/internal/colorscheme/HueShiftColorScheme.java
+++ b/substance/src/main/java/org/pushingpixels/substance/internal/colorscheme/HueShiftColorScheme.java
@@ -98,7 +98,7 @@ public class HueShiftColorScheme extends BaseColorScheme {
 	public HueShiftColorScheme(SubstanceColorScheme origScheme,
 			double hueShiftFactor) {
 		super("Hue-shift " + origScheme.getDisplayName() + " "
-				+ (int) (100 * hueShiftFactor) + "%", origScheme.isDark());
+				+ (int) (100 * hueShiftFactor) + "%", getResolver(origScheme));
 		this.hueShiftFactor = hueShiftFactor;
 		this.origScheme = origScheme;
 		this.foregroundColor = SubstanceColorUtilities.getHueShiftedColor(

--- a/substance/src/main/java/org/pushingpixels/substance/internal/colorscheme/InvertedColorScheme.java
+++ b/substance/src/main/java/org/pushingpixels/substance/internal/colorscheme/InvertedColorScheme.java
@@ -90,7 +90,7 @@ public class InvertedColorScheme extends BaseColorScheme {
 	 *            The original color scheme.
 	 */
 	public InvertedColorScheme(SubstanceColorScheme origScheme) {
-		super("Inverted " + origScheme.getDisplayName(), !origScheme.isDark());
+		super("Inverted " + origScheme.getDisplayName(), getResolver(origScheme).invert());
 		this.origScheme = origScheme;
 		this.foregroundColor = SubstanceColorUtilities.invertColor(origScheme
 				.getForegroundColor());

--- a/substance/src/main/java/org/pushingpixels/substance/internal/colorscheme/NegatedColorScheme.java
+++ b/substance/src/main/java/org/pushingpixels/substance/internal/colorscheme/NegatedColorScheme.java
@@ -89,7 +89,7 @@ public class NegatedColorScheme extends BaseColorScheme {
 	 *            The original color scheme.
 	 */
 	public NegatedColorScheme(SubstanceColorScheme origScheme) {
-		super("Negated " + origScheme.getDisplayName(), !origScheme.isDark());
+		super("Negated " + origScheme.getDisplayName(), getResolver(origScheme).invert());
 		this.origScheme = origScheme;
 
 		this.foregroundColor = SubstanceColorUtilities.invertColor(origScheme

--- a/substance/src/main/java/org/pushingpixels/substance/internal/colorscheme/SaturatedColorScheme.java
+++ b/substance/src/main/java/org/pushingpixels/substance/internal/colorscheme/SaturatedColorScheme.java
@@ -99,7 +99,7 @@ public class SaturatedColorScheme extends BaseColorScheme {
 	public SaturatedColorScheme(SubstanceColorScheme origScheme,
 			double saturationFactor) {
 		super("Saturated (" + (int) (100 * saturationFactor) + "%) "
-				+ origScheme.getDisplayName(), origScheme.isDark());
+				+ origScheme.getDisplayName(), getResolver(origScheme));
 		this.saturationFactor = saturationFactor;
 		this.origScheme = origScheme;
 		this.foregroundColor = origScheme.getForegroundColor();

--- a/substance/src/main/java/org/pushingpixels/substance/internal/colorscheme/ShiftColorScheme.java
+++ b/substance/src/main/java/org/pushingpixels/substance/internal/colorscheme/ShiftColorScheme.java
@@ -33,7 +33,10 @@ import java.awt.Color;
 
 import org.pushingpixels.substance.api.SubstanceColorScheme;
 import org.pushingpixels.substance.api.colorscheme.BaseColorScheme;
-import org.pushingpixels.substance.internal.utils.*;
+import org.pushingpixels.substance.internal.utils.HashMapKey;
+import org.pushingpixels.substance.internal.utils.LazyResettableHashMap;
+import org.pushingpixels.substance.internal.utils.SubstanceColorUtilities;
+import org.pushingpixels.substance.internal.utils.SubstanceCoreUtilities;
 
 /**
  * Base class for shifted color schemes. A shifted color scheme is based on some
@@ -154,8 +157,7 @@ public class ShiftColorScheme extends BaseColorScheme {
 				+ backgroundShiftColor + "] "
 				+ (int) (100 * backgroundShiftFactor) + "%, foregr ["
 				+ foregroundShiftColor + "]"
-				+ (int) (100 * foregroundShiftFactor) + "%", origScheme
-				.isDark());
+				+ (int) (100 * foregroundShiftFactor) + "%", getResolver(origScheme));
 		this.backgroundShiftColor = backgroundShiftColor;
 		this.backgroundShiftFactor = backgroundShiftFactor;
 		this.foregroundShiftColor = foregroundShiftColor;


### PR DESCRIPTION
https://github.com/Insubstantial/insubstantial/issues/68

Reworked the derived colors and BaseColorScheme to use immutable,
flyweights and forward resolvers to derived color schemes.

This change introduces new API:
- SchemeDerivedColorsResolver is similar to SchemeDerivedColors, but
  each method takes a SubstanceColorScheme.  This allows
  implementations to create classes that are preferably immutable,
  but, at the very least, stateless.  Note class documentation asks
  implementations to be immutable.
- BaseColorScheme gains a new protected constructor that takes a 
  SchemeDerivedColorsResolver.  This allows derived color schemes to
  reuse the same color resolver.
- Both the original BaseColorScheme constructor and the new 
  SchemeDerivedColorsResolver one defer to a third private
  constructor.

This change attempts to maintain backward compatibility:
- SchemeDerivedColorsResolver contains an isDark method.  This is 
  designed to ease migration for current SubstanceColorScheme
  implementations.
- The BaseColorScheme private constructor helps maintain the backwards
  compatibility by allowing the isDark nature to be retained.
- The new protected static method BaseColorScheme.getResolver aids
  implementations is determining the current
  SchemeDerivedColorsResolver and more easily use the new 
  BaseColorScheme constructor.

This change is API breaking in the following ways:
- The SchemeDerivedColorsResolver interface (new) replaces the current
  interface parent of SchemeDerivedColors for
  DerivedColorsResolverLight and DerivedColorsResolverDark.  It also
  replaces the SchemeDerivedColors for the field
  BaseColorScheme.derivedColorsResolver.

This change introduces the following unresolved bugs:
- Because SchemeDerivedColorsResolver implementations are supposed to
  be immutable, the current implementations should be made final.  One
  of them, DerivedColorsResolverLight, is public and cannot be made
  final without adding more API breakage, cf. previous section.
