### PR TITLE
Enable system appropriate text AA, a la core LAFs

### DIFF
--- a/substance/src/main/java/org/pushingpixels/substance/api/AASupport.java
+++ b/substance/src/main/java/org/pushingpixels/substance/api/AASupport.java
@@ -1,0 +1,69 @@
+package org.pushingpixels.substance.api;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+
+class AASupport {
+    public static final String DESKTOPFONTHINTS;
+    
+    static {
+        String hintHolder = null;
+        
+        try {
+            Class<?> toolkit = Class.forName("sun.awt.SunToolkit");
+            Field hints = toolkit.getField("DESKTOPFONTHINTS");
+            hintHolder = (String) hints.get(null);
+        } catch (RuntimeException e) {
+            throw new ExceptionInInitializerError(e);
+        } catch (Exception e) {
+            hintHolder = "awt.font.desktophints"; // currrent value for reference property
+        }
+        
+        DESKTOPFONTHINTS = hintHolder;
+    }
+    
+    public static final Object AA_TEXT_PROPERTY_KEY;
+    
+    static {
+        Object propertyHolder = null;
+        
+        try {
+            Class<?> toolkit = Class.forName("sun.swing.SwingUtilities2");
+            Field utilities = toolkit.getField("AA_TEXT_PROPERTY_KEY");
+            propertyHolder = utilities.get(null);
+        } catch (RuntimeException e) {
+            throw new ExceptionInInitializerError(e);
+        } catch (Exception e) {
+            propertyHolder = new Object(); // fake value
+        }
+        
+        AA_TEXT_PROPERTY_KEY = propertyHolder;
+    }
+    
+    private static final Method getAATextInfo;
+    
+    static {
+        Method method = null;
+        
+        try {
+            Class<?> aaTextInfo = Class.forName("sun.swing.SwingUtilities2$AATextInfo");
+            method = aaTextInfo.getDeclaredMethod("getAATextInfo", boolean.class);
+        } catch (RuntimeException e) {
+            throw new ExceptionInInitializerError(e);
+        } catch (Exception ignore) { }
+        
+        getAATextInfo = method;
+    }
+    
+    public static Object getAATextInfo(boolean lafCondition) {
+        if (getAATextInfo != null) {
+            try {
+                return getAATextInfo.invoke(null, lafCondition);
+            } catch (RuntimeException e) {
+                throw e;
+            } catch (Exception ignore) { }
+        }
+        
+        return null;
+    }
+}

--- a/substance/src/main/java/org/pushingpixels/substance/api/SubstanceLookAndFeel.java
+++ b/substance/src/main/java/org/pushingpixels/substance/api/SubstanceLookAndFeel.java
@@ -33,6 +33,8 @@ import java.awt.*;
 import java.awt.image.BufferedImage;
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
+import java.lang.ref.ReferenceQueue;
+import java.lang.ref.WeakReference;
 import java.lang.reflect.InvocationTargetException;
 import java.util.*;
 
@@ -1238,7 +1240,7 @@ public abstract class SubstanceLookAndFeel extends BasicLookAndFeel {
 	 * Class loader for {@link #LABEL_BUNDLE}.
 	 */
 	private static ClassLoader labelBundleClassLoader;
-
+	
 	/**
 	 * The skin of this look-and-feel instance.
 	 */
@@ -1530,6 +1532,99 @@ public abstract class SubstanceLookAndFeel extends BasicLookAndFeel {
 		table.putDefaults(uiDefaults);
 	}
 
+    //from MetalLookAndFeel
+    static class AATextListener extends WeakReference<LookAndFeel> implements PropertyChangeListener {
+
+        private String key = AASupport.DESKTOPFONTHINTS;
+
+        AATextListener(LookAndFeel laf) {
+            super(laf, queue);
+            Toolkit tk = Toolkit.getDefaultToolkit();
+            tk.addPropertyChangeListener(key, this);
+        }
+
+        @Override
+        public void propertyChange(PropertyChangeEvent pce) {
+            LookAndFeel laf = get();
+            if (laf == null || laf != UIManager.getLookAndFeel()) {
+                dispose();
+                return;
+            }
+            UIDefaults defaults = UIManager.getLookAndFeelDefaults();
+            Object aaTextInfo = AASupport.getAATextInfo(true);
+            defaults.put(AASupport.AA_TEXT_PROPERTY_KEY, aaTextInfo);
+            updateUI();
+        }
+
+        void dispose() {
+            Toolkit tk = Toolkit.getDefaultToolkit();
+            tk.removePropertyChangeListener(key, this);
+        }
+
+        /**
+         * Updates the UI of the passed in window and all its children.
+         */
+        private static void updateWindowUI(Window window) {
+            SwingUtilities.updateComponentTreeUI(window);
+            Window ownedWins[] = window.getOwnedWindows();
+            for (int i = 0; i < ownedWins.length; i++) {
+                updateWindowUI(ownedWins[i]);
+            }
+        }
+
+        /**
+         * Updates the UIs of all the known Frames.
+         */
+        private static void updateAllUIs() {
+            Frame appFrames[] = Frame.getFrames();
+            for (int j = 0; j < appFrames.length; j++) {
+                updateWindowUI(appFrames[j]);
+            }
+        }
+
+        /**
+         * Indicates if an updateUI call is pending.
+         */
+        private static boolean updatePending;
+
+        /**
+         * Sets whether or not an updateUI call is pending.
+         */
+        private static synchronized void setUpdatePending(boolean update) {
+            updatePending = update;
+        }
+
+        /**
+         * Returns true if a UI update is pending.
+         */
+        private static synchronized boolean isUpdatePending() {
+            return updatePending;
+        }
+        
+        protected void updateUI() {
+            if (!isUpdatePending()) {
+                setUpdatePending(true);
+                Runnable uiUpdater = new Runnable() {
+                        @Override
+                        public void run() {
+                            updateAllUIs();
+                            setUpdatePending(false);
+                        }
+                    };
+                SwingUtilities.invokeLater(uiUpdater);
+            }
+        }
+    }
+    
+    static ReferenceQueue<LookAndFeel> queue = new ReferenceQueue<LookAndFeel>();
+    
+    static void flushUnreferenced() {
+        AATextListener aatl;
+        while ((aatl = (AATextListener)queue.poll()) != null) {
+            aatl.dispose();
+        }
+    }
+    
 	/*
 	 * (non-Javadoc)
 	 * 
@@ -1540,6 +1635,18 @@ public abstract class SubstanceLookAndFeel extends BasicLookAndFeel {
 	@Override
 	protected void initComponentDefaults(UIDefaults table) {
 		super.initComponentDefaults(table);
+		
+        flushUnreferenced(); // Remove old listeners
+
+        /*
+         * Put the desktop AA settings in the defaults. JComponent.setUI() retrieves this and makes
+         * it available as a client property on the JComponent. Use the same key name for both
+         * client property and UIDefaults. Also need to set up listeners for changes in these
+         * settings.
+         */
+        Object aaTextInfo = AASupport.getAATextInfo(true);
+        table.put(AASupport.AA_TEXT_PROPERTY_KEY, aaTextInfo);
+        new AATextListener(this);
 
 		initFontDefaults(table);
 		this.skin.addCustomEntriesToTable(table);


### PR DESCRIPTION
Use reflection to set up and utilize the antialiasing features hidden in
the sun.\* packages.  The reflection is safe, ensuring that failures to 
initialize or utilize the reflected code do not leak.  The fallback for
reflection failures is the current painting approach.

This approach works with Oracle JREs.  Given the new Oracle JRE on Mac,
this code addresses Windows, Mac, and Linux releases effectively.  Note,
this change will not affect pre-Oracle, Apple JREs.
