### PR TITLE
Modify base delay of TabWindowPreview

### DIFF
--- a/laf-widget/src/main/java/org/pushingpixels/lafwidget/tabbed/TabPreviewPainter.java
+++ b/laf-widget/src/main/java/org/pushingpixels/lafwidget/tabbed/TabPreviewPainter.java
@@ -182,6 +182,18 @@ public abstract class TabPreviewPainter {
 		return 0;
 	}
 
+    /**
+     * Returns delay (in milliseconds) for showing the tab preview window.
+     * The default is 2000 milliseconds (2 seconds). This function must
+     * return a non-negative value.
+     *
+     * @param tabPane
+     *            Tabbed pane.
+     * @param tabIndex
+     *            Tab index.
+     * @return Non-negative delay (in milliseconds) for showing the tab
+     *         preview window.
+     */
     public int getPreviewWindowDelay(JTabbedPane tabPane, int tabIndex) {
         return 2000;
     }

--- a/laf-widget/src/main/java/org/pushingpixels/lafwidget/tabbed/TabPreviewPainter.java
+++ b/laf-widget/src/main/java/org/pushingpixels/lafwidget/tabbed/TabPreviewPainter.java
@@ -176,10 +176,15 @@ public abstract class TabPreviewPainter {
 	 *            Tab index.
 	 * @return Non-negative extra delay (in milliseconds) for showing the tab
 	 *         preview window.
+     * @deprecated use #getPreviewWindowDelay instead
 	 */
 	public int getPreviewWindowExtraDelay(JTabbedPane tabPane, int tabIndex) {
 		return 0;
 	}
+
+    public int getPreviewWindowDelay(JTabbedPane tabPane, int tabIndex) {
+        return 2000;
+    }
 
 	/**
 	 * Returns indication whether the thumbnail preview should be updated

--- a/laf-widget/src/main/java/org/pushingpixels/lafwidget/tabbed/TabPreviewWindow.java
+++ b/laf-widget/src/main/java/org/pushingpixels/lafwidget/tabbed/TabPreviewWindow.java
@@ -47,6 +47,7 @@ import org.pushingpixels.trident.Timeline;
  * @author Kirill Grouchnikov
  */
 public class TabPreviewWindow extends JWindow implements ActionListener {
+
 	public static final class PreviewLabel extends JLabel {
 		float alpha = 0.0f;
 
@@ -227,10 +228,12 @@ public class TabPreviewWindow extends JWindow implements ActionListener {
 			throw new IllegalArgumentException(
 					"Extra delay for tab preview must be non-negative");
 		}
-        // original 2000ms delay
-//		currTabPreviewTimer = new Timer(2000 + extraDelay, this);
-        // changed original delay to zero to show preview immediately
-		currTabPreviewTimer = new Timer(0 + extraDelay, this);
+        int delay = previewPainter.getPreviewWindowDelay(tabPane, tabIndex);
+        if (delay < 0) {
+            throw new IllegalArgumentException(
+                    "Delay for tab preview must be non-negative");
+        }
+        currTabPreviewTimer = new Timer(delay + extraDelay, this);
 		currTabPreviewTimer.setRepeats(false);
 		currTabPreviewTimer.start();
 	}

--- a/laf-widget/src/main/java/org/pushingpixels/lafwidget/tabbed/TabPreviewWindow.java
+++ b/laf-widget/src/main/java/org/pushingpixels/lafwidget/tabbed/TabPreviewWindow.java
@@ -227,7 +227,10 @@ public class TabPreviewWindow extends JWindow implements ActionListener {
 			throw new IllegalArgumentException(
 					"Extra delay for tab preview must be non-negative");
 		}
-		currTabPreviewTimer = new Timer(2000 + extraDelay, this);
+        // original 2000ms delay
+//		currTabPreviewTimer = new Timer(2000 + extraDelay, this);
+        // changed original delay to zero to show preview immediately
+		currTabPreviewTimer = new Timer(0 + extraDelay, this);
 		currTabPreviewTimer.setRepeats(false);
 		currTabPreviewTimer.start();
 	}


### PR DESCRIPTION
My current customer needs to display the TabPreviewWindow at once instead of the base delay of 2000ms. As a soft migration I made the base delay customizable. The extra delay still exists but is deprecated.
