### PR TITLE
FIX #130 Chaotic mouse rollover painting on JTable (java8)

### DIFF
--- a/substance/src/main/java/org/pushingpixels/substance/internal/ui/SubstanceTableUI.java
+++ b/substance/src/main/java/org/pushingpixels/substance/internal/ui/SubstanceTableUI.java
@@ -1779,11 +1779,11 @@ public class SubstanceTableUI extends BasicTableUI implements
 		 */
 		@Override
 		public int compareTo(TableCellId o) {
-            if (row == o.row) {
-                return Integer.compare(column, o.column);
-            } else {
-                return Integer.compare(row, o.row);
-            }
+			if (row == o.row) {
+				return Integer.compare(column, o.column);
+			} else {
+				return Integer.compare(row, o.row);
+			}
 		}
 
 		/*
@@ -1801,12 +1801,12 @@ public class SubstanceTableUI extends BasicTableUI implements
 
 		/*
 		 * (non-Javadoc)
-		 * 
+		 *
 		 * @see java.lang.Object#hashCode()
 		 */
 		@Override
 		public int hashCode() {
-            return (this.row ^ (this.row << 16))
+			return (this.row ^ (this.row << 16))
 					& (this.column ^ (this.column << 16));
 		}
 

--- a/substance/src/main/java/org/pushingpixels/substance/internal/ui/SubstanceTableUI.java
+++ b/substance/src/main/java/org/pushingpixels/substance/internal/ui/SubstanceTableUI.java
@@ -1779,9 +1779,11 @@ public class SubstanceTableUI extends BasicTableUI implements
 		 */
 		@Override
 		public int compareTo(TableCellId o) {
-			if ((this.row == o.row) && (this.column == o.column))
-				return 0;
-			return 1;
+            if (row == o.row) {
+                return Integer.compare(column, o.column);
+            } else {
+                return Integer.compare(row, o.row);
+            }
 		}
 
 		/*
@@ -1804,14 +1806,13 @@ public class SubstanceTableUI extends BasicTableUI implements
 		 */
 		@Override
 		public int hashCode() {
-            //noinspection ShiftOutOfRange
-            return (this.row ^ (this.row >>> 32))
-					& (this.column ^ (this.column >>> 32));
+            return (this.row ^ (this.row << 16))
+					& (this.column ^ (this.column << 16));
 		}
 
 		/*
 		 * (non-Javadoc)
-		 * 
+		 *
 		 * @see java.lang.Object#toString()
 		 */
 		@Override

--- a/substance/src/main/java/org/pushingpixels/substance/internal/ui/SubstanceTableUI.java
+++ b/substance/src/main/java/org/pushingpixels/substance/internal/ui/SubstanceTableUI.java
@@ -1780,9 +1780,9 @@ public class SubstanceTableUI extends BasicTableUI implements
 		@Override
 		public int compareTo(TableCellId o) {
 			if (row == o.row) {
-				return Integer.compare(column, o.column);
+				return (column < o.column) ? -1 : ((column == o.column) ? 0 : 1);
 			} else {
-				return Integer.compare(row, o.row);
+				return (row < o.row) ? -1 : ((row == o.row) ? 0 : 1);
 			}
 		}
 


### PR DESCRIPTION
compareTo should follow the contract
sgn(x.compareTo(y)) == -sgn(y.compareTo(x))

fix TableCellId hashCode (it was equal 0 for all values)
