### PR TITLE
Fixes #143: IllegalArgumentException in ribbon band title calculation

### DIFF
--- a/substance-flamingo/src/main/java/org/pushingpixels/substance/flamingo/ribbon/ui/SubstanceRibbonBandUI.java
+++ b/substance-flamingo/src/main/java/org/pushingpixels/substance/flamingo/ribbon/ui/SubstanceRibbonBandUI.java
@@ -141,10 +141,15 @@ public class SubstanceRibbonBandUI extends BasicRibbonBandUI {
 
 		int currLength = (int) fm.getStringBounds(title, g2d).getWidth();
 		String titleToPaint = title;
-		while (currLength > titleRectangle.width) {
+		
+		while ((currLength > titleRectangle.width) && (title.length() > 0)) {
 			title = title.substring(0, title.length() - 1);
 			titleToPaint = title + "...";
 			currLength = (int) fm.getStringBounds(titleToPaint, g2d).getWidth();
+		}
+		
+		if (currLength > titleRectangle.width) {
+			titleToPaint = "";
 		}
 
 		SubstanceSkin skin = SubstanceCoreUtilities.getSkin(this.ribbonBand);


### PR DESCRIPTION
If the band's width (`titleRectangle.width`) is too small to fit any characters in the title, then `title.substring(0, title.length() - 1)` will throw an IllegalArgumentException when `title.length() == 0`.

This may be caused by custom Windows display settings.  On two Windows machines running identical code, only one experienced this error.
